### PR TITLE
feat: add ModSecurity API endpoint whitelist

### DIFF
--- a/docker/proxy/config/modsecurity/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+++ b/docker/proxy/config/modsecurity/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
@@ -8,6 +8,15 @@
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
 
+
+# API端点白名单
+SecRule REQUEST_URI "@rx ^/(api/|w9proxy/api/|w9deployment/api/|w9git/api/|media/)" \
+    "id:1004,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ctl:ruleRemoveByTag=OWASP_CRS"
+
 #
 # The purpose of this file is to hold LOCAL exceptions for your site.  The
 # types of rules that would go into this file are one where you want to
@@ -198,13 +207,3 @@
 #           ctl:ruleRemoveById=920280,\
 #           ctl:ruleRemoveById=920350,\
 #           ctl:ruleRemoveByTag=attack-disclosure"
-
-
-# API端点白名单
-# SecRule REQUEST_URI "@rx ^/(api/|w9proxy/api/|w9deployment/api/)" \
-#     "id:1004,\
-#     phase:1,\
-#     pass,\
-#     nolog,\
-#     ctl:ruleRemoveById=911100,\
-#     ctl:ruleRemoveById=930120"


### PR DESCRIPTION
Prevent false positives for /api/, /w9proxy/api/, /w9deployment/api/, /w9git/api/, /media/ paths.