### PR TITLE
fix install_app.sh

### DIFF
--- a/scripts/install_app.sh
+++ b/scripts/install_app.sh
@@ -147,7 +147,7 @@ install_app(){
   proxy_enabled=$(get_proxy_enabled "$domain_names")
   filename="/tmp/library/apps/${appname}/.env"
   settings=$(get_settings "${filename}")
-  api_url="localhost/api/apps/install"
+  api_url="localhost:8080/api/apps/install"
   api_key=$(sudo docker exec -i websoft9-apphub apphub getconfig --section api_key --key key)
   request_param=$(jq -n \
                     --arg app_name "$appname" \
@@ -169,20 +169,20 @@ install_app(){
                       "settings": $settings
                     }')
 
-  response=$(curl -s -w "\n%{http_code}" -X POST "$api_url" \
-                  -H "Content-Type: application/json" \
-                  -H "x-api-key: $api_key" \
-                  -d "$request_param")
+  response=$(sudo docker exec -i websoft9-apphub sh -c "curl -s -w '\n%{http_code}' -X POST '$api_url' \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: $api_key' \
+        -d '$request_param'")
   echo "$response"
   
 }
 
 app_list(){
-  api_url="localhost/api/apps"
+  api_url="localhost:8080/api/apps"
   api_key=$(sudo docker exec -i websoft9-apphub apphub getconfig --section api_key --key key)
-  response=$(curl -s -w "\n%{http_code}" -X GET "$api_url" \
-                  -H "Content-Type: application/json" \
-                  -H "x-api-key: $api_key")
+  response=$(sudo docker exec websoft9-apphub sh -c "curl -s -w '\n%{http_code}' -X GET '$api_url' \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: $api_key'")
   echo "$response"
 }
 


### PR DESCRIPTION
**Problem**:
The websoft9-apphub container ports are not mapped to the host, causing the installation script to fail with 404 connection errors when trying to access the API service inside the container.

**Solution**:
Changed API calls from host execution to container-internal execution to bypass port mapping limitations:

1. Use `docker exec` in `install_app()` function to execute installation API calls inside the container
2. Similarly use container-internal execution in `app_list()` function for application status checks
3. Maintain existing business logic and parameter processing unchanged

**Verification**:
After the fix, the application installation process works normally, API calls return HTTP 200, and container creation and status check functions work properly.

**Impact**:
Only fixes installation functionality, does not affect existing installed applications, and does not change API interfaces or data structures.